### PR TITLE
adds defaultProps and propTypes to components

### DIFF
--- a/src/components/FeedbackItem.js
+++ b/src/components/FeedbackItem.js
@@ -1,4 +1,5 @@
 import Card from './shared/Card';
+import PropTypes from 'prop-types';
 
 function FeedbackItem ({item}) {
     return (
@@ -7,6 +8,10 @@ function FeedbackItem ({item}) {
             <div className="text-display">{item.text}</div>
         </Card>
     )
+}
+
+FeedbackItem.propTypes = {
+    item: PropTypes.object.isRequired
 }
 
 export default FeedbackItem;

--- a/src/components/FeedbackList.js
+++ b/src/components/FeedbackList.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import FeedbackItem from './FeedbackItem';
+import PropTypes from 'prop-types';
 
 function FeedbackList({feedback}) {
     if(!feedback || feedback.length === 0) {
@@ -15,5 +16,15 @@ function FeedbackList({feedback}) {
         </div>
     )
 };
+
+FeedbackList.propTypes = {
+    feedback: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.number.isRequired,
+            text: PropTypes.string.isRequired,
+            rating: PropTypes.number.isRequired
+        })
+    )
+}
 
 export default FeedbackList;

--- a/src/components/shared/Card.js
+++ b/src/components/shared/Card.js
@@ -1,7 +1,17 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 function Card({children, reverse}) {
     return <div className={`card ${reverse && 'reverse'}`}>{children}</div>
 };
+
+Card.defaultProps = {
+    reverse: false
+}
+
+Card.propTypes = {
+    children: PropTypes.node.isRequired,
+    reverse: PropTypes.bool
+}
 
 export default Card;


### PR DESCRIPTION
In the `FeedbackItem.js` file, `PropTypes` is imported at the top.  Then at the bottom, the `item` argument used in the component is set to be an `object` that `isRequired`.  

In the `FeedbackList.js` file, `PropTypes` is imported at the top.  Then at the bottom, several items are set with a `PropType` that are part of the `feedback` argument.  The `id` is set to be a number, the `text` is set to be a string, and the `rating` is set to be a number.  All three of these are then set to be `isRequired`. 

In the `shared/Card.js` file, `PropTypes` is imported at the top.  Then at the bottom, the `children` argument used in the component is set to be a `node` that `isRequired`.  Also, `reverse` is set to be a boolean with `bool`.  The `defaultProps` is also used, with `reverse` set to `false`.