### PR TITLE
adds a delete button with icon from react-icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.4.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -13896,6 +13897,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -26452,6 +26461,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.4.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/components/FeedbackItem.js
+++ b/src/components/FeedbackItem.js
@@ -1,10 +1,15 @@
-import Card from './shared/Card';
+import { FaTimes } from 'react-icons/fa';
 import PropTypes from 'prop-types';
+import Card from './shared/Card';
+
 
 function FeedbackItem ({item}) {
     return (
-        <Card reverse={true}>
+        <Card>
             <div className="num-display">{item.rating}</div>
+            <button className="close">
+                <FaTimes color="purple" />
+            </button>
             <div className="text-display">{item.text}</div>
         </Card>
     )


### PR DESCRIPTION
A package is installed from NPM called "React Icons".  

In the `FeedbackItem.js` file, a specific icon is imported named `FaTimes` from the `react-icons/fa` library.  This will access the selected icon from Font Awesome library within this package.  Then in the `return`, below the `div` that contains the rating, a `button` element is added.  This is given a class name of "close".  Inside the `button`, a single `FaTimes` element is added.  This is given a property of `color` that is set to purple.  

A couple minor changes also was moving the `import` for `Card` to the top.  Also, in the `Card` element, the `reverse` property that was set to true was removed, so that this remains false by default.  