### PR TITLE
adds defaultProps and propTypes to Button component

### DIFF
--- a/src/components/FeedbackForm.js
+++ b/src/components/FeedbackForm.js
@@ -1,5 +1,6 @@
 import React, {useState} from 'react';
 import Card from './shared/Card';
+import Button from './shared/Button';
 
 function FeedbackForm() {
     const [text, setText] = useState('');
@@ -20,7 +21,7 @@ function FeedbackForm() {
                         placeholder="Write a review"
                         value={text} 
                     />
-                    <button type="submit">Send</button>
+                    <Button type="submit">Send</Button>
                 </div>
             </form>
         </Card>

--- a/src/components/shared/Button.js
+++ b/src/components/shared/Button.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 function Button({ children, version, type, isDisabled }) {
     return (
@@ -7,5 +8,18 @@ function Button({ children, version, type, isDisabled }) {
         </button>
     )
 };
+
+Button.defaultProps = {
+    version: 'primary',
+    type: 'button',
+    isDisabled: false
+}
+
+Button.propTypes = {
+    children: PropTypes.node.isRequired,
+    version: PropTypes.string,
+    type: PropTypes.string,
+    isDisabled: PropTypes.bool,
+}
 
 export default Button;


### PR DESCRIPTION
In the `Button.js` file in the `shared` folder, several `propTypes` and `defaultProps` were added to the component.  
For the `defaultProps`, `version` was given a default of "primary", `type` was given a default of "button", and `isDisabled` is given a default of false.
For the `PropTypes`, this was first imported at the top from `prop-types`.  Then for the `PropTypes` at the bottom, `children` was set to a node, `version` was set to a string, `type` was set to a string, and `isDisabled` is set to a boolean (bool). 

Also, in the `FeedbackForm.js` file, the `Button` component is imported at the top from `shared/Button`.  Then the `<button>` element is replaced with the `Button` component.

